### PR TITLE
AutoIncrement Improvements

### DIFF
--- a/lib/mongoose/plugins/autoIncrement.js
+++ b/lib/mongoose/plugins/autoIncrement.js
@@ -63,6 +63,24 @@ module.exports = (schema, options) => {
 
   schema.add(fields)
 
+  const params = { model: settings.model, field: settings.field }
+  const initializedIdentityCounter = IdentityCounter.findOne(params).exec()
+    .then(doc => {
+      if (!doc) {
+        const params = {
+          model: settings.model,
+          field: settings.field,
+          count: settings.startAt - settings.incrementBy
+        }
+
+        doc = new IdentityCounter(params)
+        return doc.save()
+
+      }
+
+      return doc
+    })
+
   const nextCount = (callback) => {
     IdentityCounter.findOne(
       { model: settings.model, field: settings.field },
@@ -95,23 +113,25 @@ module.exports = (schema, options) => {
   schema.method('resetCount', resetCount)
   schema.static('resetCount', resetCount)
 
-  const params = { model: settings.model, field: settings.field }
-  const initializedIdentityCounter = IdentityCounter.findOne(params).exec()
-    .then(doc => {
-      if (!doc) {
-        const params = {
+  const setCustomIncrementCounter = (customIncrementValue) => {
+    return initializedIdentityCounter.then(() => {
+
+      customIncrementValue = parseInt(customIncrementValue)
+      if (customIncrementValue > 0) {
+        const query = {
           model: settings.model,
-          field: settings.field,
-          count: settings.startAt - settings.incrementBy
+          field: settings.field
         }
 
-        doc = new IdentityCounter(params)
-        return doc.save()
+        const params = { count: customIncrementValue }
 
+        return IdentityCounter.update(query, params)
       }
 
-      return doc
     })
+  }
+  schema.method('setCustomIncrementCounter', setCustomIncrementCounter)
+  schema.static('setCustomIncrementCounter', setCustomIncrementCounter)
 
   schema.pre('save', function (next) {
     const doc = this

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "api",
     "redis"
   ],
-  "version": "0.5.9",
+  "version": "0.5.10",
   "author": "Alexander Kravets <alex@slatestudio.com>",
   "contributors": [
     {


### PR DESCRIPTION
I've found problem with custom update increment counter in seed scripts. When seed script starts to write increment counter to db after writing needed documents we have conflict with auto increment plugin, if auto increment plugin does't have time to write initial counter and seed script has already written custom counter then auto increment plugin overwrite counter to db